### PR TITLE
feat: Add container settings to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,11 @@
 		"dockerfile": "Dockerfile",
 		"context": "."
 	},
+	"containerEnv": {
+		"LC_ALL": "en_US.UTF-8",
+		"TERM": "xterm-256color"
+	},
+	"containerUser": "vscode",
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"installZsh": true,


### PR DESCRIPTION
* **containerEnv**: Defines environment variables that apply even when accessing the container outside of VSCode.

  * `TERM`: Ensures `zsh-autosuggestions` suggestions appear in gray instead of white.
  * `LC_ALL`: Fixes the issue where typing `git`, pressing tab, and then deleting leaves behind `gi`.
* **containerUser**: Specifies the default login user when connecting to the container outside of VSCode (e.g., via `docker exec`).
