### PR TITLE
build: Install tmux in dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,7 @@ FROM mcr.microsoft.com/devcontainers/base:bookworm
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
     make \
+    tmux \
     vim && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Effect
If the container is created using a VSCode Dev Container, you can enjoy the same internal container setup from your local terminal as well.

### Usage
```shell
# Context: Inside the container, but outside any tmux session
tmux new -s dev
tmux detach  # Run inside tmux; shortcut is [Ctrl + b d]
tmux ls

docker exec -it <container_name> tmux attach -t dev  # From local terminal

exit  # Run inside the tmux session to exit it
tmux kill-session -t dev # Run outside the tmux session
```